### PR TITLE
Add patches for libav 10 and ffmpeg 3.0

### DIFF
--- a/ffmpeg_2.9.patch
+++ b/ffmpeg_2.9.patch
@@ -1,0 +1,351 @@
+Description: Replace deprecated FFmpeg API
+Author: Andreas Cadhalpun <Andreas.Cadhalpun@googlemail.com>
+Last-Update: <2015-11-02>
+
+--- libquicktime-1.2.4.orig/plugins/ffmpeg/audio.c
++++ libquicktime-1.2.4/plugins/ffmpeg/audio.c
+@@ -1267,7 +1267,7 @@ static int lqt_ffmpeg_encode_audio(quick
+     pkt.data = codec->chunk_buffer;
+     pkt.size = codec->chunk_buffer_alloc;
+ 
+-    avcodec_get_frame_defaults(&f);
++    av_frame_unref(&f);
+     f.nb_samples = codec->avctx->frame_size;
+     
+     avcodec_fill_audio_frame(&f, channels, codec->avctx->sample_fmt,
+--- libquicktime-1.2.4.orig/plugins/ffmpeg/params.c
++++ libquicktime-1.2.4/plugins/ffmpeg/params.c
+@@ -158,7 +158,6 @@ enum_t coder_type[] =
+     { "Arithmetic",           FF_CODER_TYPE_AC },
+     { "Raw",                  FF_CODER_TYPE_RAW },
+     { "RLE",                  FF_CODER_TYPE_RLE },
+-    { "Deflate",              FF_CODER_TYPE_DEFLATE },
+   };
+ 
+ #define PARAM_ENUM(name, var, arr) \
+@@ -253,15 +252,13 @@ void lqt_ffmpeg_set_parameter(AVCodecCon
+   PARAM_INT("ff_me_penalty_compensation",me_penalty_compensation);
+   PARAM_INT("ff_bidir_refine",bidir_refine);
+   PARAM_INT("ff_brd_scale",brd_scale);
+-  PARAM_INT("ff_scenechange_factor",scenechange_factor);
+   PARAM_FLAG("ff_flag_qscale",CODEC_FLAG_QSCALE);
+   PARAM_FLAG("ff_flag_4mv",CODEC_FLAG_4MV);
+   PARAM_FLAG("ff_flag_qpel",CODEC_FLAG_QPEL);
+-  PARAM_FLAG("ff_flag_gmc",CODEC_FLAG_GMC);
++  PARAM_DICT_FLAG("ff_flag_gmc", "gmc");
+   PARAM_FLAG("ff_flag_mv0",CODEC_FLAG_MV0);
+   //  PARAM_FLAG("ff_flag_part",CODEC_FLAG_PART); // Unused
+   PARAM_FLAG("ff_flag_gray",CODEC_FLAG_GRAY);
+-  PARAM_FLAG("ff_flag_emu_edge",CODEC_FLAG_EMU_EDGE);
+   PARAM_FLAG("ff_flag_normalize_aqp",CODEC_FLAG_NORMALIZE_AQP);
+   //  PARAM_FLAG("ff_flag_alt_scan",CODEC_FLAG_ALT_SCAN); // Unused
+ #if LIBAVCODEC_VERSION_INT < ((52<<16)+(0<<8)+0)
+--- libquicktime-1.2.4.orig/plugins/ffmpeg/params.h
++++ libquicktime-1.2.4/plugins/ffmpeg/params.h
+@@ -149,7 +149,7 @@ the reference. Unused for constant quant
+     .type =        LQT_PARAMETER_INT, \
+     .val_default = { .val_int = 0 }, \
+     .val_min =     { .val_int = 0 }, \
+-    .val_max =     { .val_int = FF_MAX_B_FRAMES }, \
++    .val_max =     { .val_int = INT_MAX }, \
+     .help_string = TRS("Maximum number of B-frames between non B-frames") \
+   }
+ 
+--- libquicktime-1.2.4.orig/plugins/ffmpeg/video.c
++++ libquicktime-1.2.4/plugins/ffmpeg/video.c
+@@ -37,10 +37,10 @@
+ #endif
+ 
+ 
+-#ifdef  PIX_FMT_YUV422P10
+-#define PIX_FMT_YUV422P10_OR_DUMMY PIX_FMT_YUV422P10
++#ifdef  AV_PIX_FMT_YUV422P10
++#define AV_PIX_FMT_YUV422P10_OR_DUMMY AV_PIX_FMT_YUV422P10
+ #else
+-#define PIX_FMT_YUV422P10_OR_DUMMY -1234
++#define AV_PIX_FMT_YUV422P10_OR_DUMMY -1234
+ #endif
+ 
+ #if LIBAVCODEC_VERSION_INT >= ((54<<16)|(1<<8)|0)
+@@ -90,9 +90,9 @@ typedef struct
+   int imx_bitrate;
+   int imx_strip_vbi;
+ 
+-  /* In some cases FFMpeg would report something like PIX_FMT_YUV422P, while
+-     we would like to treat it as PIX_FMT_YUVJ422P. It's only used for decoding */
+-  enum PixelFormat reinterpret_pix_fmt;
++  /* In some cases FFMpeg would report something like AV_PIX_FMT_YUV422P, while
++     we would like to treat it as AV_PIX_FMT_YUVJ422P. It's only used for decoding */
++  enum AVPixelFormat reinterpret_pix_fmt;
+   
+   int is_imx;
+   int y_offset;
+@@ -137,42 +137,42 @@ typedef struct
+ 
+ static const struct
+   {
+-  enum PixelFormat ffmpeg_id;
++  enum AVPixelFormat ffmpeg_id;
+   int              lqt_id;
+   int              exact;
+   }
+ colormodels[] =
+   {
+-    { PIX_FMT_YUV420P,   BC_YUV420P,   1 }, ///< Planar YUV 4:2:0 (1 Cr & Cb sample per 2x2 Y samples)
++    { AV_PIX_FMT_YUV420P,   BC_YUV420P,   1 }, ///< Planar YUV 4:2:0 (1 Cr & Cb sample per 2x2 Y samples)
+ #if LIBAVUTIL_VERSION_INT < (50<<16)
+-    { PIX_FMT_YUV422,    BC_YUV422,    1 },
++    { AV_PIX_FMT_YUV422,    BC_YUV422,    1 },
+ #else
+-    { PIX_FMT_YUYV422,   BC_YUV422,    1 },
++    { AV_PIX_FMT_YUYV422,   BC_YUV422,    1 },
+ #endif
+-    { PIX_FMT_RGB24,     BC_RGB888,    1 }, ///< Packed pixel, 3 bytes per pixel, RGBRGB...
+-    { PIX_FMT_BGR24,     BC_BGR888,    1 }, ///< Packed pixel, 3 bytes per pixel, BGRBGR...
+-    { PIX_FMT_YUV422P,   BC_YUV422P,   1 }, ///< Planar YUV 4:2:2 (1 Cr & Cb sample per 2x1 Y samples)
+-    { PIX_FMT_YUV444P,   BC_YUV444P,   1 }, ///< Planar YUV 4:4:4 (1 Cr & Cb sample per 1x1 Y samples)
+-    { PIX_FMT_YUV411P,   BC_YUV411P,   1 }, ///< Planar YUV 4:1:1 (1 Cr & Cb sample per 4x1 Y samples)
+-    { PIX_FMT_YUV422P16, BC_YUV422P16, 1 }, ///< Planar 16 bit YUV 4:2:2 (1 Cr & Cb sample per 2x1 Y samples)
+-#ifdef PIX_FMT_YUV422P10
+-    { PIX_FMT_YUV422P10, BC_YUV422P10, 1 }, ///< 10 bit samples in uint16_t containers, planar 4:2:2
+-#endif
+-    { PIX_FMT_RGB565,    BC_RGB565,    1 }, ///< always stored in cpu endianness
+-    { PIX_FMT_YUVJ420P,  BC_YUVJ420P,  1 }, ///< Planar YUV 4:2:0 full scale (jpeg)
+-    { PIX_FMT_YUVJ422P,  BC_YUVJ422P,  1 }, ///< Planar YUV 4:2:2 full scale (jpeg)
+-    { PIX_FMT_YUVJ444P,  BC_YUVJ444P,  1 }, ///< Planar YUV 4:4:4 full scale (jpeg)
++    { AV_PIX_FMT_RGB24,     BC_RGB888,    1 }, ///< Packed pixel, 3 bytes per pixel, RGBRGB...
++    { AV_PIX_FMT_BGR24,     BC_BGR888,    1 }, ///< Packed pixel, 3 bytes per pixel, BGRBGR...
++    { AV_PIX_FMT_YUV422P,   BC_YUV422P,   1 }, ///< Planar YUV 4:2:2 (1 Cr & Cb sample per 2x1 Y samples)
++    { AV_PIX_FMT_YUV444P,   BC_YUV444P,   1 }, ///< Planar YUV 4:4:4 (1 Cr & Cb sample per 1x1 Y samples)
++    { AV_PIX_FMT_YUV411P,   BC_YUV411P,   1 }, ///< Planar YUV 4:1:1 (1 Cr & Cb sample per 4x1 Y samples)
++    { AV_PIX_FMT_YUV422P16, BC_YUV422P16, 1 }, ///< Planar 16 bit YUV 4:2:2 (1 Cr & Cb sample per 2x1 Y samples)
++#ifdef AV_PIX_FMT_YUV422P10
++    { AV_PIX_FMT_YUV422P10, BC_YUV422P10, 1 }, ///< 10 bit samples in uint16_t containers, planar 4:2:2
++#endif
++    { AV_PIX_FMT_RGB565,    BC_RGB565,    1 }, ///< always stored in cpu endianness
++    { AV_PIX_FMT_YUVJ420P,  BC_YUVJ420P,  1 }, ///< Planar YUV 4:2:0 full scale (jpeg)
++    { AV_PIX_FMT_YUVJ422P,  BC_YUVJ422P,  1 }, ///< Planar YUV 4:2:2 full scale (jpeg)
++    { AV_PIX_FMT_YUVJ444P,  BC_YUVJ444P,  1 }, ///< Planar YUV 4:4:4 full scale (jpeg)
+ #if LIBAVUTIL_VERSION_INT < (50<<16)
+-    { PIX_FMT_RGBA32,    BC_RGBA8888,  0 }, ///< Packed pixel, 4 bytes per pixel, BGRABGRA...
++    { AV_PIX_FMT_RGBA32,    BC_RGBA8888,  0 }, ///< Packed pixel, 4 bytes per pixel, BGRABGRA...
+ #else
+-    { PIX_FMT_RGB32,     BC_RGBA8888,  0 }, ///< Packed pixel, 4 bytes per pixel, BGRABGRA...
++    { AV_PIX_FMT_RGB32,     BC_RGBA8888,  0 }, ///< Packed pixel, 4 bytes per pixel, BGRABGRA...
+ #endif
+-    { PIX_FMT_RGB555,    BC_RGB888,    0 }, ///< always stored in cpu endianness, most significant bit to 1
+-    { PIX_FMT_GRAY8,     BC_RGB888,    0 },
+-    { PIX_FMT_MONOWHITE, BC_RGB888,    0 }, ///< 0 is white
+-    { PIX_FMT_MONOBLACK, BC_RGB888,    0 }, ///< 0 is black
+-    { PIX_FMT_PAL8,      BC_RGB888,    0 }, ///< 8 bit with RGBA palette
+-    { PIX_FMT_YUV410P,   BC_YUV420P,   0 }, ///< Planar YUV 4:1:0 (1 Cr & Cb sample per 4x4 Y samples)
++    { AV_PIX_FMT_RGB555,    BC_RGB888,    0 }, ///< always stored in cpu endianness, most significant bit to 1
++    { AV_PIX_FMT_GRAY8,     BC_RGB888,    0 },
++    { AV_PIX_FMT_MONOWHITE, BC_RGB888,    0 }, ///< 0 is white
++    { AV_PIX_FMT_MONOBLACK, BC_RGB888,    0 }, ///< 0 is black
++    { AV_PIX_FMT_PAL8,      BC_RGB888,    0 }, ///< 8 bit with RGBA palette
++    { AV_PIX_FMT_YUV410P,   BC_YUV420P,   0 }, ///< Planar YUV 4:1:0 (1 Cr & Cb sample per 4x4 Y samples)
+   };
+ 
+ static const struct
+@@ -248,7 +248,7 @@ static int lqt_ffmpeg_delete_video(quick
+   if(codec->frame_buffer) free(codec->frame_buffer);
+   if(codec->buffer) free(codec->buffer);
+ 
+-  if(codec->frame) av_free(codec->frame);
++  if(codec->frame) av_frame_free(&codec->frame);
+ 
+ #ifdef HAVE_LIBSWSCALE
+   if(codec->swsContext)
+@@ -343,16 +343,16 @@ static int lqt_tenbit_dnxhd_supported(AV
+   if (!codec->pix_fmts)
+     return 0;
+ 
+-  for (i = 0; codec->pix_fmts[i] != PIX_FMT_NONE; ++i)
++  for (i = 0; codec->pix_fmts[i] != AV_PIX_FMT_NONE; ++i)
+     {
+-    if (codec->pix_fmts[i] == PIX_FMT_YUV422P10_OR_DUMMY)
++    if (codec->pix_fmts[i] == AV_PIX_FMT_YUV422P10_OR_DUMMY)
+       return 1;
+     }
+ 
+   return 0;
+   }
+ 
+-static enum PixelFormat lqt_ffmpeg_get_ffmpeg_colormodel(int id)
++static enum AVPixelFormat lqt_ffmpeg_get_ffmpeg_colormodel(int id)
+   {
+   int i;
+ 
+@@ -361,10 +361,10 @@ static enum PixelFormat lqt_ffmpeg_get_f
+     if(colormodels[i].lqt_id == id)
+       return colormodels[i].ffmpeg_id;
+     }
+-  return PIX_FMT_NB;
++  return AV_PIX_FMT_NB;
+   }
+ 
+-static int lqt_ffmpeg_get_lqt_colormodel(enum PixelFormat id, int * exact)
++static int lqt_ffmpeg_get_lqt_colormodel(enum AVPixelFormat id, int * exact)
+   {
+   int i;
+ 
+@@ -405,31 +405,31 @@ static void lqt_ffmpeg_setup_decoding_co
+      if (lqt_ffmpeg_get_avid_yuv_range(vtrack->track) == AVID_FULL_YUV_RANGE)
+        {
+        vtrack->stream_cmodel = BC_YUVJ422P;
+-       codec->reinterpret_pix_fmt = PIX_FMT_YUVJ422P;
++       codec->reinterpret_pix_fmt = AV_PIX_FMT_YUVJ422P;
+        *exact = 1;
+        return;
+        }
+     }
+   else if(codec->decoder->id == AV_CODEC_ID_DNXHD)
+     {
+-    /* FFMpeg supports PIX_FMT_YUV422P and PIX_FMT_YUV422P10 for DNxHD, which
+-       we sometimes interpret as PIX_FMT_YUVJ422P and PIX_FMT_YUVJ422P10. */
+-    if (codec->avctx->pix_fmt == PIX_FMT_YUV422P || codec->avctx->pix_fmt == PIX_FMT_YUV422P10_OR_DUMMY)
++    /* FFMpeg supports AV_PIX_FMT_YUV422P and AV_PIX_FMT_YUV422P10 for DNxHD, which
++       we sometimes interpret as AV_PIX_FMT_YUVJ422P and AV_PIX_FMT_YUVJ422P10. */
++    if (codec->avctx->pix_fmt == AV_PIX_FMT_YUV422P || codec->avctx->pix_fmt == AV_PIX_FMT_YUV422P10_OR_DUMMY)
+       {
+-      int p10 = (codec->avctx->pix_fmt == PIX_FMT_YUV422P10_OR_DUMMY);
++      int p10 = (codec->avctx->pix_fmt == AV_PIX_FMT_YUV422P10_OR_DUMMY);
+       *exact = 1;
+       if (lqt_ffmpeg_get_avid_yuv_range(vtrack->track) == AVID_FULL_YUV_RANGE)
+         {
+         vtrack->stream_cmodel = p10 ? BC_YUVJ422P10 : BC_YUVJ422P;
+-        codec->reinterpret_pix_fmt = p10 ? PIX_FMT_YUV422P10_OR_DUMMY : PIX_FMT_YUVJ422P;
+-        // Note: reinterpret_pix_fmt should really be PIX_FMT_YUVJ422P10, except
++        codec->reinterpret_pix_fmt = p10 ? AV_PIX_FMT_YUV422P10_OR_DUMMY : AV_PIX_FMT_YUVJ422P;
++        // Note: reinterpret_pix_fmt should really be AV_PIX_FMT_YUVJ422P10, except
+         // there is no such colormodel in FFMpeg. Fortunately, it's not a problem
+         // in this case, as reinterpret_pix_fmt is only used when *exact == 0.
+         }
+       else
+         {
+         vtrack->stream_cmodel = p10 ? BC_YUV422P10 : BC_YUV422P;
+-        codec->reinterpret_pix_fmt = p10 ? PIX_FMT_YUV422P10_OR_DUMMY : PIX_FMT_YUV422P;
++        codec->reinterpret_pix_fmt = p10 ? AV_PIX_FMT_YUV422P10_OR_DUMMY : AV_PIX_FMT_YUV422P;
+         }
+       return;
+       }
+@@ -440,14 +440,14 @@ static void lqt_ffmpeg_setup_encoding_co
+ 
+   if (codec->encoder->id == AV_CODEC_ID_DNXHD)
+     {
+-    /* FFMpeg's DNxHD encoder only supports PIX_FMT_YUV422P and PIX_FMT_YUV422P10
+-       and doesn't know anything about PIX_FMT_YUVJ422P and PIX_FMT_YUVJ422P10
++    /* FFMpeg's DNxHD encoder only supports AV_PIX_FMT_YUV422P and AV_PIX_FMT_YUV422P10
++       and doesn't know anything about AV_PIX_FMT_YUVJ422P and AV_PIX_FMT_YUVJ422P10
+        (in fact, the latter doesn't even exist) */
+-    codec->avctx->pix_fmt = PIX_FMT_YUV422P;
++    codec->avctx->pix_fmt = AV_PIX_FMT_YUV422P;
+     if (vtrack->stream_cmodel == BC_YUV422P10 || vtrack->stream_cmodel == BC_YUVJ422P10)
+       {
+       if (lqt_tenbit_dnxhd_supported(codec->encoder))
+-        codec->avctx->pix_fmt = PIX_FMT_YUV422P10_OR_DUMMY;
++        codec->avctx->pix_fmt = AV_PIX_FMT_YUV422P10_OR_DUMMY;
+       }
+     }
+   }
+@@ -458,7 +458,7 @@ static void lqt_ffmpeg_setup_encoding_co
+ /* From avcodec.h: */
+ 
+ /*
+- * PIX_FMT_RGBA32 is handled in an endian-specific manner. A RGBA
++ * AV_PIX_FMT_RGBA32 is handled in an endian-specific manner. A RGBA
+  * color is put together as:
+  *  (A << 24) | (R << 16) | (G << 8) | B
+  * This is stored as BGRA on little endian CPU architectures and ARGB on
+@@ -530,7 +530,7 @@ static void convert_rgba_to_argb(uint8_t
+  */
+ 
+ static void convert_image_decode(quicktime_ffmpeg_video_codec_t *codec,
+-                                 AVFrame * in_frame, enum PixelFormat in_format,
++                                 AVFrame * in_frame, enum AVPixelFormat in_format,
+                                  unsigned char ** out_frame, int out_format,
+                                  int width, int height, int row_span, int row_span_uv)
+   {
+@@ -547,9 +547,9 @@ static void convert_image_decode(quickti
+    *  RGBA format like in ffmpeg??
+    */
+ #if LIBAVUTIL_VERSION_INT < (50<<16)
+-  if((in_format == PIX_FMT_RGBA32) && (out_format == BC_RGBA8888))
++  if((in_format == AV_PIX_FMT_RGBA32) && (out_format == BC_RGBA8888))
+ #else
+-    if((in_format == PIX_FMT_RGB32) && (out_format == BC_RGBA8888))
++    if((in_format == AV_PIX_FMT_RGB32) && (out_format == BC_RGBA8888))
+ #endif
+       {
+       convert_image_decode_rgba(in_frame, out_frame, width, height, codec->y_offset);
+@@ -829,7 +829,7 @@ static int lqt_ffmpeg_decode_video(quick
+     if(avcodec_open2(codec->avctx, codec->decoder, NULL) != 0)
+       return -1;
+ #endif
+-    codec->frame = avcodec_alloc_frame();
++    codec->frame = av_frame_alloc();
+     vtrack->stream_cmodel = LQT_COLORMODEL_NONE;
+     codec->initialized = 1;
+     }
+@@ -929,10 +929,10 @@ static int lqt_ffmpeg_decode_video(quick
+ #ifdef HAVE_LIBSWSCALE
+ 
+ #if LIBAVUTIL_VERSION_INT < (50<<16)
+-      if(!((codec->avctx->pix_fmt == PIX_FMT_RGBA32) &&
++      if(!((codec->avctx->pix_fmt == AV_PIX_FMT_RGBA32) &&
+            (vtrack->stream_cmodel == BC_RGBA8888)))
+ #else
+-        if(!((codec->avctx->pix_fmt == PIX_FMT_RGB32) &&
++        if(!((codec->avctx->pix_fmt == AV_PIX_FMT_RGB32) &&
+              (vtrack->stream_cmodel == BC_RGBA8888)))
+ #endif
+           {
+@@ -1318,7 +1318,7 @@ static int lqt_ffmpeg_encode_video(quick
+         
+   if(!codec->initialized)
+     {
+-    codec->frame = avcodec_alloc_frame();
++    codec->frame = av_frame_alloc();
+ 
+     /* time_base is 1/framerate for constant framerate */
+           
+@@ -1396,9 +1396,9 @@ static int lqt_ffmpeg_encode_video(quick
+       if(vtrack->stream_cmodel == BC_RGBA8888)
+         {
+         /* Libquicktime doesn't natively support a color model equivalent
+-           to PIX_FMT_ARGB, which is required for QTRLE with alpha channel.
++           to AV_PIX_FMT_ARGB, which is required for QTRLE with alpha channel.
+            So, we use BC_RGBA8888 and do ad hoc conversion below. */
+-        codec->avctx->pix_fmt = PIX_FMT_ARGB;
++        codec->avctx->pix_fmt = AV_PIX_FMT_ARGB;
+         vtrack->track->mdia.minf.stbl.stsd.table[0].depth = 32;
+         }
+       }
+@@ -1467,7 +1467,7 @@ static int lqt_ffmpeg_encode_video(quick
+     }
+   //        codec->lqt_colormodel = ffmepg_2_lqt(codec->com.ffcodec_enc);
+ 
+-  if(codec->y_offset != 0 || codec->avctx->pix_fmt == PIX_FMT_ARGB)
++  if(codec->y_offset != 0 || codec->avctx->pix_fmt == AV_PIX_FMT_ARGB)
+     {
+     if(!codec->tmp_rows)
+       {
+@@ -1492,7 +1492,7 @@ static int lqt_ffmpeg_encode_video(quick
+                         vtrack->stream_cmodel,
+                         0, 0, 0, codec->y_offset);
+       }
+-    else if(codec->avctx->pix_fmt == PIX_FMT_ARGB)
++    else if(codec->avctx->pix_fmt == AV_PIX_FMT_ARGB)
+       {
+       convert_rgba_to_argb(row_pointers[0], vtrack->stream_row_span,
+                            codec->tmp_rows[0], codec->tmp_row_span,
+@@ -1600,7 +1600,7 @@ static int lqt_ffmpeg_encode_video(quick
+       {
+       int advanced = 0;
+       if(codec->avctx->max_b_frames ||
+-         (codec->avctx->flags & (CODEC_FLAG_QPEL|CODEC_FLAG_GMC)))
++         (codec->avctx->flags & (AV_CODEC_FLAG_QPEL|CODEC_FLAG_GMC)))
+         advanced = 1;
+ 
+       setup_header_mpeg4(file, track, codec->avctx->extradata,

--- a/libav10.patch
+++ b/libav10.patch
@@ -1,0 +1,654 @@
+Description: build against libav10 (Closes: #739325)
+Author: Reinhard Tartler <siretart@tauware.de>
+Bug-Debian: http://bugs.debian.org/739325
+Last-Update: 2014-03-16
+
+
+--- libquicktime-1.2.4.orig/plugins/ffmpeg/lqt_ffmpeg.c
++++ libquicktime-1.2.4/plugins/ffmpeg/lqt_ffmpeg.c
+@@ -386,7 +386,7 @@ static lqt_image_size_static_t image_siz
+ struct CODECIDMAP codecidmap_v[] =
+   {
+     {
+-      .id = CODEC_ID_MPEG1VIDEO,
++      .id = AV_CODEC_ID_MPEG1VIDEO,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -397,7 +397,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE }
+     },
+     {
+-      .id = CODEC_ID_MPEG4,
++      .id = AV_CODEC_ID_MPEG4,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -415,7 +415,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .compression_id = LQT_COMPRESSION_MPEG4_ASP,
+     },
+     {
+-      .id = CODEC_ID_MSMPEG4V1,
++      .id = AV_CODEC_ID_MSMPEG4V1,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -426,7 +426,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_MSMPEG4V2,
++      .id = AV_CODEC_ID_MSMPEG4V2,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -437,7 +437,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_MSMPEG4V3,
++      .id = AV_CODEC_ID_MSMPEG4V3,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -453,7 +453,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .do_encode = 1,
+     },
+     {
+-      .id = CODEC_ID_MSMPEG4V3,
++      .id = AV_CODEC_ID_MSMPEG4V3,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -468,7 +468,7 @@ struct CODECIDMAP codecidmap_v[] =
+     },
+ #if 0
+     {
+-      .id = CODEC_ID_WMV1,
++      .id = AV_CODEC_ID_WMV1,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -481,7 +481,7 @@ struct CODECIDMAP codecidmap_v[] =
+     },
+ #endif
+     {
+-      .id = CODEC_ID_H263,
++      .id = AV_CODEC_ID_H263,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -493,7 +493,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .compatibility_flags = LQT_FILE_QT_OLD | LQT_FILE_QT | LQT_FILE_MP4 | LQT_FILE_3GP,
+     },
+     {
+-      .id = CODEC_ID_H263,
++      .id = AV_CODEC_ID_H263,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -508,7 +508,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .do_encode = 1,
+     },
+     {
+-      .id = CODEC_ID_H264,
++      .id = AV_CODEC_ID_H264,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -519,7 +519,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_H263P,
++      .id = AV_CODEC_ID_H263P,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -533,7 +533,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .do_encode = 1,
+     },
+     {
+-      .id = CODEC_ID_H263I,
++      .id = AV_CODEC_ID_H263I,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -544,7 +544,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_SVQ1,
++      .id = AV_CODEC_ID_SVQ1,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -555,7 +555,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_SVQ3,
++      .id = AV_CODEC_ID_SVQ3,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -566,7 +566,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_MJPEG,
++      .id = AV_CODEC_ID_MJPEG,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -580,7 +580,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .do_encode = 1,
+     },
+     {
+-      .id = CODEC_ID_MJPEGB,
++      .id = AV_CODEC_ID_MJPEGB,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -594,7 +594,7 @@ struct CODECIDMAP codecidmap_v[] =
+     },
+ #if LIBAVCODEC_BUILD >= 3346688
+     {
+-      .id = CODEC_ID_TARGA,
++      .id = AV_CODEC_ID_TARGA,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -606,7 +606,7 @@ struct CODECIDMAP codecidmap_v[] =
+ #endif
+ #if LIBAVCODEC_BUILD >= 3347456
+     {
+-      .id = CODEC_ID_TIFF,
++      .id = AV_CODEC_ID_TIFF,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -617,7 +617,7 @@ struct CODECIDMAP codecidmap_v[] =
+     },
+ #endif
+     {
+-      .id = CODEC_ID_8BPS,
++      .id = AV_CODEC_ID_8BPS,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -627,7 +627,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_INDEO3,
++      .id = AV_CODEC_ID_INDEO3,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -638,7 +638,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_RPZA,
++      .id = AV_CODEC_ID_RPZA,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -648,7 +648,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_SMC,
++      .id = AV_CODEC_ID_SMC,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -658,7 +658,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_CINEPAK,
++      .id = AV_CODEC_ID_CINEPAK,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -669,7 +669,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_CYUV,
++      .id = AV_CODEC_ID_CYUV,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -680,7 +680,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_QTRLE,
++      .id = AV_CODEC_ID_QTRLE,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -693,7 +693,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .encoding_colormodels = (int[]){ BC_RGB888, BC_RGBA8888, LQT_COLORMODEL_NONE },
+     },
+     {
+-      .id = CODEC_ID_MSRLE,
++      .id = AV_CODEC_ID_MSRLE,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -703,7 +703,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .wav_ids = { LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_DVVIDEO,
++      .id = AV_CODEC_ID_DVVIDEO,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -719,7 +719,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .image_sizes = image_sizes_dv,
+     },
+     {
+-      .id = CODEC_ID_DVVIDEO,
++      .id = AV_CODEC_ID_DVVIDEO,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -735,7 +735,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .image_sizes = image_sizes_dv,
+     },
+     {
+-      .id = CODEC_ID_DVVIDEO,
++      .id = AV_CODEC_ID_DVVIDEO,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -751,7 +751,7 @@ struct CODECIDMAP codecidmap_v[] =
+     },
+     /* DVCPRO HD (decoding only for now) */
+     {
+-      .id = CODEC_ID_DVVIDEO,
++      .id = AV_CODEC_ID_DVVIDEO,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -772,7 +772,7 @@ struct CODECIDMAP codecidmap_v[] =
+       // .do_encode = 1
+     },
+     {
+-      .id = CODEC_ID_FFVHUFF,
++      .id = AV_CODEC_ID_FFVHUFF,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -785,7 +785,7 @@ struct CODECIDMAP codecidmap_v[] =
+       .do_encode = 1
+     },
+     {
+-      .id = CODEC_ID_FFV1,
++      .id = AV_CODEC_ID_FFV1,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -801,7 +801,7 @@ struct CODECIDMAP codecidmap_v[] =
+     },
+ #if LIBAVCODEC_BUILD >= 3352576
+     {
+-      .id = CODEC_ID_DNXHD,
++      .id = AV_CODEC_ID_DNXHD,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -817,7 +817,7 @@ struct CODECIDMAP codecidmap_v[] =
+     },
+ #endif
+     {
+-      .id = CODEC_ID_MPEG2VIDEO,
++      .id = AV_CODEC_ID_MPEG2VIDEO,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -839,7 +839,7 @@ struct CODECIDMAP codecidmap_v[] =
+ struct CODECIDMAP codecidmap_a[] =
+   {
+     {
+-      .id = CODEC_ID_MP3,
++      .id = AV_CODEC_ID_MP3,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -851,7 +851,7 @@ struct CODECIDMAP codecidmap_a[] =
+       .wav_ids = { 0x50, 0x55, LQT_WAV_ID_NONE },
+     },
+     {
+-      .id = CODEC_ID_MP2,
++      .id = AV_CODEC_ID_MP2,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -866,7 +866,7 @@ struct CODECIDMAP codecidmap_a[] =
+       .compression_id = LQT_COMPRESSION_MP2,
+     },
+     {
+-      .id = CODEC_ID_AC3,
++      .id = AV_CODEC_ID_AC3,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -881,7 +881,7 @@ struct CODECIDMAP codecidmap_a[] =
+       .compression_id = LQT_COMPRESSION_AC3,
+     },
+     {
+-      .id = CODEC_ID_QDM2,
++      .id = AV_CODEC_ID_QDM2,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -896,7 +896,7 @@ struct CODECIDMAP codecidmap_a[] =
+ #if 1
+     /* Doesn't work as long as audio chunks are not split into VBR "Samples" */
+     {
+-      .id = CODEC_ID_ALAC,
++      .id = AV_CODEC_ID_ALAC,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -909,7 +909,7 @@ struct CODECIDMAP codecidmap_a[] =
+ #if 1
+     /* Sounds ugly */
+     {
+-      .id = CODEC_ID_ADPCM_MS,
++      .id = AV_CODEC_ID_ADPCM_MS,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+@@ -922,7 +922,7 @@ struct CODECIDMAP codecidmap_a[] =
+ #if 1
+     /* Sounds ugly */
+     {
+-      .id = CODEC_ID_ADPCM_IMA_WAV,
++      .id = AV_CODEC_ID_ADPCM_IMA_WAV,
+       .index = -1,
+       .encoder = NULL,
+       .decoder = NULL,
+--- libquicktime-1.2.4.orig/plugins/ffmpeg/audio.c
++++ libquicktime-1.2.4/plugins/ffmpeg/audio.c
+@@ -626,7 +632,7 @@ static int decode_chunk(quicktime_t * fi
+     {
+     /* If the codec is mp3, make sure to decode the very last frame */
+ 
+-    if((codec->avctx->codec_id == CODEC_ID_MP3) &&
++    if((codec->avctx->codec_id == AV_CODEC_ID_MP3) &&
+        (codec->bytes_in_chunk_buffer >= 4))
+       {
+       if(!mpa_decode_header(&mph, codec->chunk_buffer, (const mpa_header*)0))
+@@ -695,7 +701,7 @@ static int decode_chunk(quicktime_t * fi
+     
+     /* Some really broken mp3 files have the header bytes split across 2 chunks */
+ 
+-    if(codec->avctx->codec_id == CODEC_ID_MP3)
++    if(codec->avctx->codec_id == AV_CODEC_ID_MP3)
+       {
+       if(codec->bytes_in_chunk_buffer < 4)
+         {
+@@ -806,7 +812,7 @@ static int decode_chunk(quicktime_t * fi
+     
+     if(bytes_decoded < 0)
+       {
+-      if(codec->avctx->codec_id == CODEC_ID_MP3)
++      if(codec->avctx->codec_id == AV_CODEC_ID_MP3)
+         {
+         /* For mp3, bytes_decoded < 0 means, that the frame should be muted */
+         memset(&codec->sample_buffer[track_map->channels * (codec->sample_buffer_end -
+@@ -866,8 +872,8 @@ static void init_compression_info(quickt
+   quicktime_audio_map_t *track_map = &file->atracks[track];
+   quicktime_ffmpeg_audio_codec_t *codec = track_map->codec->priv;
+ 
+-  if((codec->decoder->id == CODEC_ID_MP2) ||
+-     (codec->decoder->id == CODEC_ID_MP3))
++  if((codec->decoder->id == AV_CODEC_ID_MP2) ||
++     (codec->decoder->id == AV_CODEC_ID_MP3))
+     {
+     mpa_header h;
+     uint32_t header;
+@@ -909,7 +915,7 @@ static void init_compression_info(quickt
+     else
+       track_map->ci.bitrate = h.bitrate;
+     }
+-  else if(codec->decoder->id == CODEC_ID_AC3)
++  else if(codec->decoder->id == AV_CODEC_ID_AC3)
+     {
+     a52_header h;
+     uint8_t * ptr;
+@@ -986,7 +992,7 @@ static int lqt_ffmpeg_decode_audio(quick
+ #endif
+     /* Some codecs need extra stuff */
+ 
+-    if(codec->decoder->id == CODEC_ID_ALAC)
++    if(codec->decoder->id == AV_CODEC_ID_ALAC)
+       {
+       header = quicktime_wave_get_user_atom(track_map->track, "alac", &header_len);
+       if(header)
+@@ -995,7 +1001,7 @@ static int lqt_ffmpeg_decode_audio(quick
+         codec->avctx->extradata_size = header_len;
+         }
+       }
+-    if(codec->decoder->id == CODEC_ID_QDM2)
++    if(codec->decoder->id == AV_CODEC_ID_QDM2)
+       {
+       header = quicktime_wave_get_user_atom(track_map->track, "QDCA", &header_len);
+       if(header)
+@@ -1495,9 +1501,9 @@ void quicktime_init_audio_codec_ffmpeg(q
+     codec_base->decode_audio = lqt_ffmpeg_decode_audio;
+   codec_base->set_parameter = set_parameter;
+ 
+-  if((decoder->id == CODEC_ID_MP3) || (decoder->id == CODEC_ID_MP2))
++  if((decoder->id == AV_CODEC_ID_MP3) || (decoder->id == AV_CODEC_ID_MP2))
+     codec_base->read_packet = read_packet_mpa;
+-  else if(decoder->id == CODEC_ID_AC3)
++  else if(decoder->id == AV_CODEC_ID_AC3)
+     {
+     codec_base->write_packet = write_packet_ac3;
+     codec_base->read_packet = read_packet_ac3;
+--- libquicktime-1.2.4.orig/plugins/ffmpeg/video.c
++++ libquicktime-1.2.4/plugins/ffmpeg/video.c
+@@ -400,7 +400,7 @@ static void lqt_ffmpeg_setup_decoding_co
+        return;
+        }
+     }
+-  else if(codec->decoder->id == CODEC_ID_DNXHD)
++  else if(codec->decoder->id == AV_CODEC_ID_DNXHD)
+     {
+     /* FFMpeg supports PIX_FMT_YUV422P and PIX_FMT_YUV422P10 for DNxHD, which
+        we sometimes interpret as PIX_FMT_YUVJ422P and PIX_FMT_YUVJ422P10. */
+@@ -438,7 +438,7 @@ static void lqt_ffmpeg_setup_encoding_co
+   quicktime_ffmpeg_video_codec_t *codec = vtrack->codec->priv;
+   codec->avctx->pix_fmt = lqt_ffmpeg_get_ffmpeg_colormodel(vtrack->stream_cmodel);
+ 
+-  if (codec->encoder->id == CODEC_ID_DNXHD)
++  if (codec->encoder->id == AV_CODEC_ID_DNXHD)
+     {
+     /* FFMpeg's DNxHD encoder only supports PIX_FMT_YUV422P and PIX_FMT_YUV422P10
+        and doesn't know anything about PIX_FMT_YUVJ422P and PIX_FMT_YUVJ422P10
+@@ -728,13 +728,13 @@ static int lqt_ffmpeg_decode_video(quick
+ 
+     /* Set extradata: It's done differently for each codec */
+ 
+-    if(codec->decoder->id == CODEC_ID_SVQ3)
++    if(codec->decoder->id == AV_CODEC_ID_SVQ3)
+       {
+       extradata       = trak->mdia.minf.stbl.stsd.table[0].table_raw + 4;
+       extradata_size  = trak->mdia.minf.stbl.stsd.table[0].table_raw_size - 4;
+       
+       }
+-    else if(codec->decoder->id == CODEC_ID_H264)
++    else if(codec->decoder->id == AV_CODEC_ID_H264)
+       {
+       user_atom = quicktime_stsd_get_user_atom(trak, "avcC", &user_atom_len);
+ 
+@@ -753,7 +753,7 @@ static int lqt_ffmpeg_decode_video(quick
+         }
+       
+       }
+-    else if(codec->decoder->id == CODEC_ID_MPEG4)
++    else if(codec->decoder->id == AV_CODEC_ID_MPEG4)
+       {
+       if(trak->mdia.minf.stbl.stsd.table[0].has_esds)
+         {
+@@ -947,15 +947,15 @@ static int lqt_ffmpeg_decode_video(quick
+           }
+ #endif
+       }
+-    if(codec->decoder->id == CODEC_ID_DVVIDEO)
++    if(codec->decoder->id == AV_CODEC_ID_DVVIDEO)
+       {
+       if(vtrack->stream_cmodel == BC_YUV420P)
+         vtrack->chroma_placement = LQT_CHROMA_PLACEMENT_DVPAL;
+       vtrack->interlace_mode = LQT_INTERLACE_BOTTOM_FIRST;
+       vtrack->ci.id = LQT_COMPRESSION_DV;
+       }
+-    else if((codec->decoder->id == CODEC_ID_MPEG4) ||
+-            (codec->decoder->id == CODEC_ID_H264))
++    else if((codec->decoder->id == AV_CODEC_ID_MPEG4) ||
++            (codec->decoder->id == AV_CODEC_ID_H264))
+       {
+       if(vtrack->stream_cmodel == BC_YUV420P)
+         vtrack->chroma_placement = LQT_CHROMA_PLACEMENT_MPEG2;
+@@ -1299,13 +1299,13 @@ static int lqt_ffmpeg_encode_video(quick
+     {
+     if(vtrack->stream_cmodel == BC_YUV420P)
+       {
+-      if(codec->encoder->id == CODEC_ID_MPEG4)
++      if(codec->encoder->id == AV_CODEC_ID_MPEG4)
+         {
+         vtrack->chroma_placement = LQT_CHROMA_PLACEMENT_MPEG2;
+         /* enable interlaced encoding */
+         vtrack->interlace_mode = LQT_INTERLACE_NONE;
+         }
+-      else if(codec->encoder->id == CODEC_ID_DVVIDEO)
++      else if(codec->encoder->id == AV_CODEC_ID_DVVIDEO)
+         {
+         vtrack->chroma_placement = LQT_CHROMA_PLACEMENT_DVPAL;
+         }
+@@ -1340,7 +1340,7 @@ static int lqt_ffmpeg_encode_video(quick
+     codec->avctx->sample_aspect_ratio.num = pixel_width;
+     codec->avctx->sample_aspect_ratio.den = pixel_height;
+     /* Use global headers for mp4v */
+-    if(codec->encoder->id == CODEC_ID_MPEG4)
++    if(codec->encoder->id == AV_CODEC_ID_MPEG4)
+       {
+       if(!(file->file_type & (LQT_FILE_AVI|LQT_FILE_AVI_ODML)))
+         {
+@@ -1364,12 +1364,12 @@ static int lqt_ffmpeg_encode_video(quick
+         }
+ #endif
+       }
+-    else if((codec->encoder->id == CODEC_ID_MSMPEG4V3) && (trak->strl) &&
++    else if((codec->encoder->id == AV_CODEC_ID_MSMPEG4V3) && (trak->strl) &&
+             !strncmp(trak->strl->strf.bh.biCompression, "DIV3", 4))
+       {
+       strncpy(trak->strl->strh.fccHandler, "div3", 4);
+       }
+-    else if((codec->encoder->id == CODEC_ID_H263) &&
++    else if((codec->encoder->id == AV_CODEC_ID_H263) &&
+             (file->file_type & (LQT_FILE_MP4|LQT_FILE_3GP)))
+       {
+       uint8_t d263_data[] =
+@@ -1383,7 +1383,7 @@ static int lqt_ffmpeg_encode_video(quick
+       strncpy(trak->mdia.minf.stbl.stsd.table[0].format,
+               "s263", 4);
+       }
+-    else if(codec->encoder->id == CODEC_ID_FFVHUFF)
++    else if(codec->encoder->id == AV_CODEC_ID_FFVHUFF)
+       {
+       if(!(file->file_type & (LQT_FILE_AVI|LQT_FILE_AVI_ODML)))
+         {
+@@ -1391,7 +1391,7 @@ static int lqt_ffmpeg_encode_video(quick
+         codec->write_global_header = 1;
+         }
+       }
+-    else if(codec->encoder->id == CODEC_ID_QTRLE)
++    else if(codec->encoder->id == AV_CODEC_ID_QTRLE)
+       {
+       if(vtrack->stream_cmodel == BC_RGBA8888)
+         {
+@@ -1402,11 +1402,11 @@ static int lqt_ffmpeg_encode_video(quick
+         vtrack->track->mdia.minf.stbl.stsd.table[0].depth = 32;
+         }
+       }
+-    else if(codec->encoder->id == CODEC_ID_DVVIDEO)
++    else if(codec->encoder->id == AV_CODEC_ID_DVVIDEO)
+       {
+       set_dv_fourcc(width, height, vtrack->stream_cmodel, trak);
+       }
+-    else if(codec->encoder->id == CODEC_ID_DNXHD)
++    else if(codec->encoder->id == AV_CODEC_ID_DNXHD)
+       {
+       if(vtrack->interlace_mode != LQT_INTERLACE_NONE)
+         {
+@@ -1558,12 +1558,12 @@ static int lqt_ffmpeg_encode_video(quick
+   
+ #endif
+   
+-  if(!was_initialized && codec->encoder->id == CODEC_ID_DNXHD)
++  if(!was_initialized && codec->encoder->id == AV_CODEC_ID_DNXHD)
+     setup_avid_atoms(file, vtrack, codec->buffer, bytes_encoded);
+   
+   if(bytes_encoded)
+     {
+-    if (pts == AV_NOPTS_VALUE || (codec->encoder->id == CODEC_ID_DNXHD && pts == 0))
++    if (pts == AV_NOPTS_VALUE || (codec->encoder->id == AV_CODEC_ID_DNXHD && pts == 0))
+       {
+       /* Some codecs don't bother generating presentation timestamps.
+          FFMpeg's DNxHD encoder doesn't even bother to set it to AV_NOPTS_VALUE. */
+@@ -1590,13 +1590,13 @@ static int lqt_ffmpeg_encode_video(quick
+ 
+   if(codec->write_global_header && !codec->global_header_written)
+     {
+-    if(codec->encoder->id == CODEC_ID_FFVHUFF)
++    if(codec->encoder->id == AV_CODEC_ID_FFVHUFF)
+       {
+       quicktime_user_atoms_add_atom(&trak->mdia.minf.stbl.stsd.table[0].user_atoms,
+                                     "glbl",
+                                     codec->avctx->extradata, codec->avctx->extradata_size );
+       }
+-    else if(codec->encoder->id == CODEC_ID_MPEG4)
++    else if(codec->encoder->id == AV_CODEC_ID_MPEG4)
+       {
+       int advanced = 0;
+       if(codec->avctx->max_b_frames ||
+@@ -1903,18 +1903,18 @@ void quicktime_init_video_codec_ffmpeg(q
+     codec_base->encode_video = lqt_ffmpeg_encode_video;
+     codec_base->set_pass = set_pass_ffmpeg;
+ 
+-    if(encoder->id == CODEC_ID_MPEG4)
++    if(encoder->id == AV_CODEC_ID_MPEG4)
+       {
+       codec_base->writes_compressed = writes_compressed_mpeg4;
+       codec_base->init_compressed   = init_compressed_mpeg4;
+       codec_base->write_packet = write_packet_mpeg4;
+       }
+-    else if(encoder->id == CODEC_ID_MPEG2VIDEO)
++    else if(encoder->id == AV_CODEC_ID_MPEG2VIDEO)
+       {
+       codec_base->writes_compressed = writes_compressed_imx;
+       codec_base->init_compressed   = init_compressed_imx;
+       }
+-    else if(encoder->id == CODEC_ID_DVVIDEO)
++    else if(encoder->id == AV_CODEC_ID_DVVIDEO)
+       {
+       codec_base->init_compressed = init_compressed_dv;
+       }
+@@ -1922,7 +1922,7 @@ void quicktime_init_video_codec_ffmpeg(q
+     }
+   if(decoder)
+     {
+-    if(decoder->id == CODEC_ID_H264)
++    if(decoder->id == AV_CODEC_ID_H264)
+       codec_base->read_packet = read_packet_h264;
+     codec_base->decode_video = lqt_ffmpeg_decode_video;
+     }

--- a/libquicktime.spec
+++ b/libquicktime.spec
@@ -7,6 +7,7 @@ Group: 		System Environment/Libraries
 URL: 		http://libquicktime.sourceforge.net/
 Source0: 	http://downloads.sourceforge.net/libquicktime/%{name}-%{version}.tar.gz
 Patch0:         libquicktime-backport.patch
+Patch1:         libav10.patch
 
 BuildRequires:	libdv-devel
 BuildRequires:	libpng-devel libjpeg-devel libGLU-devel
@@ -58,6 +59,7 @@ enhancements. This package contains development files for %{name}.
 %prep
 %setup -q
 %patch0 -p1
+%patch1 -p1
 
 
 # --------------------------------------------------------------------

--- a/libquicktime.spec
+++ b/libquicktime.spec
@@ -8,6 +8,7 @@ URL: 		http://libquicktime.sourceforge.net/
 Source0: 	http://downloads.sourceforge.net/libquicktime/%{name}-%{version}.tar.gz
 Patch0:         libquicktime-backport.patch
 Patch1:         libav10.patch
+Patch2:         ffmpeg_2.9.patch
 
 BuildRequires:	libdv-devel
 BuildRequires:	libpng-devel libjpeg-devel libGLU-devel
@@ -60,6 +61,7 @@ enhancements. This package contains development files for %{name}.
 %setup -q
 %patch0 -p1
 %patch1 -p1
+%patch2 -p1
 
 
 # --------------------------------------------------------------------

--- a/libquicktime.spec
+++ b/libquicktime.spec
@@ -1,7 +1,7 @@
 Summary: 	Library for reading and writing Quicktime files
 Name: 		libquicktime
 Version:	1.2.4
-Release:	20%{?dist}
+Release:	21%{?dist}
 License:	LGPLv2+
 Group: 		System Environment/Libraries
 URL: 		http://libquicktime.sourceforge.net/
@@ -126,6 +126,9 @@ find $RPM_BUILD_ROOT%{_libdir} -type f -a -name \*.la -exec rm {} \;
 # --------------------------------------------------------------------
 
 %changelog
+* Sat May 14 2016 Michael Kuhn <suraia@ikkoku.de> - 1.2.4-21
+- Add patches for libav 10 and ffmpeg 3.0.
+
 * Mon Oct 26 2015 Nicolas Chauvet <kwizart@gmail.com> - 1.2.4-20
 - Bump for x264
 


### PR DESCRIPTION
I just updated a few packages for Fedora 24 and also updated ffmpeg to version 3.0. To make libquicktime build with this ffmpeg version, two patches are required. They are taken from the Debian package and adapted to fit into the RPM Fusion package.
